### PR TITLE
Fixed a small typo in the bitnami deprecation blog post

### DIFF
--- a/blog/2025/08/21/bitnami-deprecation/index.html
+++ b/blog/2025/08/21/bitnami-deprecation/index.html
@@ -190,7 +190,7 @@
 
 <p>I’ve long said that, when using container images in production, it’s vitally important that you build and maintain all of your own images, or if you want have some kind of commercial maintenance agreement for them. Relying on freely provided externally managed images is a recipe for problems down the line.</p>
 
-<p>For now though, the critical point is that everyone using Bitnami images, needs to go an review all their usage and make a fairly rapid plan to address the risk of them breaking in the near future.</p>
+<p>For now though, the critical point is that everyone using Bitnami images, needs to go and review all their usage and make a fairly rapid plan to address the risk of them breaking in the near future.</p>
 
 	  </div>
 


### PR DESCRIPTION
Hi, I found a small typo that I fixed.

- `go an review` → `go and review`